### PR TITLE
fix(parse): fix address in log

### DIFF
--- a/parse/src/log.rs
+++ b/parse/src/log.rs
@@ -432,7 +432,7 @@ pub fn parse(lines: impl IntoIterator<Item = impl AsRef<str>>) -> Result<NeonLog
         current_order += 1;
         event.level = event_level;
         event.order = current_order;
-        event.address = event_addr;
+        event.address = event.address.or(event_addr);
     }
 
     let log_info = NeonLogInfo {


### PR DESCRIPTION
reference: https://github.com/neonlabsorg/proxy-model.py/blob/149298b924d7cbf5e02eb85eac041b63e21e59d5/proxy/common_neon/evm_log_decoder.py#L192