### PR TITLE
block_number return either reliable last empty slot or last slot processed by indexer

### DIFF
--- a/db/.sqlx/query-1dac0f5f9647427104214fa9ee7b8de4fc202f0d47353ee9821f92b595360043.json
+++ b/db/.sqlx/query-1dac0f5f9647427104214fa9ee7b8de4fc202f0d47353ee9821f92b595360043.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO reliable_empty_slot (block_slot) VALUES ($1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1dac0f5f9647427104214fa9ee7b8de4fc202f0d47353ee9821f92b595360043"
+}

--- a/db/.sqlx/query-c23e3b451bf05ebdde8fb73b66121a34e94a9e32862d3aa7a06b5241db5ebd56.json
+++ b/db/.sqlx/query-c23e3b451bf05ebdde8fb73b66121a34e94a9e32862d3aa7a06b5241db5ebd56.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM reliable_empty_slot",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "c23e3b451bf05ebdde8fb73b66121a34e94a9e32862d3aa7a06b5241db5ebd56"
+}

--- a/db/.sqlx/query-d0604d33bf2691dc8c28dab73ac00a4bd097735283d7bd58121e12090114690a.json
+++ b/db/.sqlx/query-d0604d33bf2691dc8c28dab73ac00a4bd097735283d7bd58121e12090114690a.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT MAX(slot) AS \"slot!\"\n                FROM (\n                    SELECT MAX(block_slot) AS slot\n                    FROM solana_blocks\n                    WHERE is_finalized = $1 OR $2\n                    UNION ALL\n                    SELECT MAX(block_slot) AS slot\n                    FROM reliable_empty_slot\n                ) AS combined_slots\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "slot!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "d0604d33bf2691dc8c28dab73ac00a4bd097735283d7bd58121e12090114690a"
+}

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,4 +1,5 @@
 mod block;
+mod reliable_empty_slot;
 mod transaction;
 
 use std::str::FromStr;
@@ -11,6 +12,7 @@ use sqlx::PgPool;
 use thiserror::Error;
 
 pub use block::{BlockBy, BlockRepo};
+pub use reliable_empty_slot::ReliableEmptySlotRepo;
 pub use transaction::{RichLog, RichLogBy, TransactionBy, TransactionRepo, WithBlockhash};
 
 pub async fn connect(url: &str) -> Result<PgPool, sqlx::Error> {

--- a/db/src/reliable_empty_slot.rs
+++ b/db/src/reliable_empty_slot.rs
@@ -1,0 +1,49 @@
+use super::Error;
+
+#[derive(Debug, Clone)]
+pub struct ReliableEmptySlotRepo {
+    pool: sqlx::PgPool,
+}
+
+impl ReliableEmptySlotRepo {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn update_or_insert(&self, slot: u64) -> Result<(), sqlx::Error> {
+        let mut txn = self.pool.begin().await?;
+        sqlx::query!("DELETE FROM reliable_empty_slot")
+            .execute(&mut *txn)
+            .await?;
+        sqlx::query!(
+            r#"INSERT INTO reliable_empty_slot (block_slot) VALUES ($1)"#,
+            slot as i64
+        )
+        .execute(&mut *txn)
+        .await?;
+        txn.commit().await?;
+        Ok(())
+    }
+
+    pub async fn latest_number(&self, is_finalized: bool) -> Result<u64, Error> {
+        let num = sqlx::query!(
+            r#"
+                SELECT MAX(slot) AS "slot!"
+                FROM (
+                    SELECT MAX(block_slot) AS slot
+                    FROM solana_blocks
+                    WHERE is_finalized = $1 OR $2
+                    UNION ALL
+                    SELECT MAX(block_slot) AS slot
+                    FROM reliable_empty_slot
+                ) AS combined_slots
+            "#,
+            is_finalized,
+            !is_finalized
+        )
+        .fetch_one(&self.pool)
+        .await?
+        .slot as u64;
+        Ok(num)
+    }
+}

--- a/schemas/migrations/02_add_reliable_empty_slot_table.sql
+++ b/schemas/migrations/02_add_reliable_empty_slot_table.sql
@@ -1,0 +1,3 @@
+ CREATE TABLE IF NOT EXISTS reliable_empty_slot (
+     block_slot BIGINT PRIMARY KEY
+ );

--- a/schemas/scheme.sql
+++ b/schemas/scheme.sql
@@ -244,8 +244,4 @@
         data_offset BIGINT,
         data BYTEA
     );
-    CREATE INDEX IF NOT EXISTS pubkey_slot ON neon_holder_log(pubkey, block_slot, tx_idx);
-
-    CREATE TABLE IF NOT EXISTS reliable_empty_slot (
-        block_slot BIGINT PRIMARY KEY
-    );
+    CREATE INDEX IF NOT EXISTS pubkey_slot ON neon_holder_log(pubkey, block_slot, tx_idx);-- Add migration script here

--- a/schemas/scheme.sql
+++ b/schemas/scheme.sql
@@ -245,3 +245,7 @@
         data BYTEA
     );
     CREATE INDEX IF NOT EXISTS pubkey_slot ON neon_holder_log(pubkey, block_slot, tx_idx);
+
+    CREATE TABLE IF NOT EXISTS reliable_empty_slot (
+        block_slot BIGINT PRIMARY KEY
+    );

--- a/solana-api/examples/scan-transactions.rs
+++ b/solana-api/examples/scan-transactions.rs
@@ -117,6 +117,10 @@ async fn main() -> Result<()> {
                 println!("===== Purged Block {slot} =====");
                 println!();
             }
+            LedgerItem::ReliableLastEmptySlot(slot) => {
+                println!("===== Reliable Last Empty Slot {slot} =====");
+                println!();
+            }
         }
     }
     Ok(())

--- a/solana-api/src/solana_api.rs
+++ b/solana-api/src/solana_api.rs
@@ -122,6 +122,10 @@ impl SolanaApi {
             .await
     }
 
+    pub async fn get_slot(&self) -> ClientResult<Slot> {
+        self.client.get_slot().await
+    }
+
     pub async fn get_block(&self, slot: Slot) -> ClientResult<UiConfirmedBlock> {
         metrics().get_block.inc();
         self.client

--- a/solana-api/src/solana_api.rs
+++ b/solana-api/src/solana_api.rs
@@ -122,8 +122,12 @@ impl SolanaApi {
             .await
     }
 
-    pub async fn get_slot(&self) -> ClientResult<Slot> {
-        self.client.get_slot().await
+    pub async fn get_slot_with_commitment(&self) -> ClientResult<Slot> {
+        self.client
+            .get_slot_with_commitment(CommitmentConfig {
+                commitment: self.commitment,
+            })
+            .await
     }
 
     pub async fn get_block(&self, slot: Slot) -> ClientResult<UiConfirmedBlock> {

--- a/solana-api/src/traverse.rs
+++ b/solana-api/src/traverse.rs
@@ -460,7 +460,7 @@ impl InnerTraverseLedger {
             // Sorted from the most recent to the oldest
             let txs = loop {
                 if earliest.is_none() {
-                    match self.api.get_slot().await {
+                    match self.api.get_slot_with_commitment().await {
                         Ok(slot) => {
                             latest_slot = Some(slot);
                         }

--- a/solana-api/src/traverse.rs
+++ b/solana-api/src/traverse.rs
@@ -497,9 +497,6 @@ impl InnerTraverseLedger {
                     continue;
                 }
                 tracing::debug!("stopping traverse, empty response");
-                if let Some(latest_slot) = latest_slot {
-                    self.reliable_last_empty_slot.replace(latest_slot);
-                }
                 break 'outer;
             }
             empty_retries = 0;
@@ -583,6 +580,11 @@ impl InnerTraverseLedger {
         );
 
         self.buffer.extend(new_signatures);
+        if self.buffer.is_empty() {
+            if let Some(latest_slot) = latest_slot {
+                self.reliable_last_empty_slot.replace(latest_slot);
+            }
+        }
         metrics().traverse.buffer_len.set(self.buffer.len() as i64);
         metrics().traverse.uncommited_buffer_len.set(0);
     }


### PR DESCRIPTION
I have a concern regarding the proposed implementation:

We request `getSlot` with the `finalized` commitment, but our implementation of `block_number` doesn’t consider the commitment for the processed slot (which makes sense). Should we request `getSlot` with the same commitment we use for the `indexer`, and additionally request the block for the slot, then monitor it to remove it if it gets purged?