### PR TITLE
proxy: properly handle "latest" and "pending" tags; fallback to rpc client when CH is not available

### DIFF
--- a/proxy/src/neon_api.rs
+++ b/proxy/src/neon_api.rs
@@ -69,7 +69,8 @@ async fn build_rpc(
                 CallDbClient::new(tracer_db.clone(), slot, tx_index_in_block).await?,
             ))
         } else {
-            Err(NeonError::InvalidChDbConfig)
+            warn!("tracer_db is not configured, falling back to RpcClient");
+            Ok(RpcEnum::CloneRpcClient(rpc_client.clone()))
         }
     } else {
         Ok(RpcEnum::CloneRpcClient(rpc_client.clone()))

--- a/proxy/src/rpc.rs
+++ b/proxy/src/rpc.rs
@@ -115,6 +115,7 @@ impl EthApiImpl {
         Ok(Some(build_block(block, txs, full)?.into()))
     }
 
+    /// Returns none for latest, and pending
     async fn get_slot_by_block_id(&self, block_id: BlockId) -> RpcResult<Option<u64>> {
         match block_id {
             BlockId::Hash(hash) => {
@@ -125,6 +126,7 @@ impl EthApiImpl {
                     .await?;
                 Ok(block.and_then(|block| block.header.number))
             }
+            BlockId::Number(BlockNumberOrTag::Pending | BlockNumberOrTag::Latest) => Ok(None),
             BlockId::Number(tag) => Ok(Some(self.find_slot(tag).await?)),
         }
     }


### PR DESCRIPTION
1. For `latest` and `pending` tags return null slot and use solana rpc client; 
2. When tracer db is not available always fallback to solana rpc