### PR TITLE
fix(proxy): default gas price and limit for eth_call to 2**64

### DIFF
--- a/proxy/src/neon_api.rs
+++ b/proxy/src/neon_api.rs
@@ -526,6 +526,7 @@ impl NeonApi {
                     tx,
                     solana_overrides: None,
                 };
+                tracing::info!(?req, "emulate_call");
                 let resp = commands::emulate::execute(
                     &ctx.default_rpc,
                     ctx.neon_pubkey,

--- a/proxy/src/rpc.rs
+++ b/proxy/src/rpc.rs
@@ -471,6 +471,9 @@ impl EthApiServer for EthApiImpl {
             None
         };
 
+        let gas = U256::from(request.gas.unwrap_or(1 << 64)).to_neon();
+        let gas_price = U256::from(request.gas.unwrap_or(1 << 64)).to_neon();
+
         let tx = TxParams {
             nonce: request.nonce,
             from: request.from.map(ToNeon::to_neon).unwrap_or_default(),
@@ -481,8 +484,8 @@ impl EthApiServer for EthApiImpl {
             },
             data: request.input.data.map(|data| data.to_vec()),
             value: request.value.map(ToNeon::to_neon),
-            gas_limit: request.gas.map(U256::from).map(ToNeon::to_neon),
-            gas_price: request.gas_price.map(U256::from).map(ToNeon::to_neon),
+            gas_limit: Some(gas),
+            gas_price: Some(gas_price),
             access_list: request
                 .access_list
                 .map(|list| list.0.into_iter().map(ToNeon::to_neon).collect()),


### PR DESCRIPTION
reference: https://github.com/neonlabsorg/neon-proxy.py/blob/b166ecf0d5907322860a2f96c8c2013aed316120/proxy/base/rpc_api.py#L60