### PR TITLE
fix(proxy): set default operator fee to 0.1

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -163,7 +163,7 @@ struct Args {
     /// Constant gas price
     const_gas_price: Option<u128>,
 
-    #[arg(long, env, default_value = "50000")]
+    #[arg(long, env, default_value = "10000")]
     /// Operator fee
     operator_fee: u128,
 


### PR DESCRIPTION
https://github.com/neonlabsorg/neon-proxy.py/blob/d6cf4ad5af31d57eae3aa30254f44f471cb64006/common/config/config.py#L670