### PR TITLE
fix(db): fix tx_log_idx

### DIFF
--- a/db/src/transaction.rs
+++ b/db/src/transaction.rs
@@ -382,6 +382,13 @@ impl TransactionRepo {
             block_hash,
             tx_idx,
         } = by.params();
+        tracing::debug!(
+            ?slot,
+            ?tx_hash,
+            ?block_hash,
+            ?tx_idx,
+            "fetching transactions with events"
+        );
         sqlx::query_as::<_, NeonTransactionRowWithLogs>(
             r#"SELECT * FROM
                    (WITH tx_block_slot AS
@@ -407,7 +414,7 @@ impl TransactionRepo {
                       B.block_hash,
 
                       L.address, L.tx_log_idx,
-                      (row_number() OVER (PARTITION BY T.block_slot ORDER BY L.block_slot,L.tx_idx,L.tx_log_idx))-1 as log_idx,
+                      (row_number() OVER (PARTITION BY T.block_slot,T.tx_idx ORDER BY L.block_slot,L.tx_idx,L.tx_log_idx))-1 as log_idx,
                       L.event_level, L.event_order,
                       L.log_topic1, L.log_topic2,
                       L.log_topic3, L.log_topic4,


### PR DESCRIPTION
If we have multiple txs in a block, partitioning log records by `block_slot` only is not enough