### PR TITLE
Revert "fix(solana-api): remove rpc bug workaround in v2 traverse"

### DIFF
--- a/solana-api/src/traverse/v2.rs
+++ b/solana-api/src/traverse/v2.rs
@@ -24,6 +24,7 @@ use crate::finalization_tracker::{BlockStatus, FinalizationTracker};
 
 const ERROR_RECHECK_INTERVAL: Duration = Duration::from_secs(1);
 const REGULAR_RECHECK_INTERVAL: Duration = Duration::from_millis(400);
+const EMPTY_BLOCK_RETRIES: u32 = 10;
 
 macro_rules! retry {
     ($val:expr, $message:literal) => {
@@ -176,6 +177,7 @@ impl TraverseLedger {
     }
 
     async fn get_block(api: &SolanaApi, slot: u64, full: bool) -> Option<UiConfirmedBlock> {
+        let mut empty_retries = 0;
         loop {
             match api.get_block(slot, full).await {
                 Ok(block) => {
@@ -191,6 +193,14 @@ impl TraverseLedger {
                         })
                     ) =>
                 {
+                    // This is a hack to work around RPC missing blocks.
+                    // TODO: Remove it after the problem is fixed
+                    if empty_retries < EMPTY_BLOCK_RETRIES {
+                        tracing::warn!(%slot, "retrying missing block");
+                        empty_retries += 1;
+                        sleep(ERROR_RECHECK_INTERVAL).await;
+                        continue;
+                    }
                     tracing::info!(%slot, "skipped slot");
                     break None;
                 }


### PR DESCRIPTION
This reverts commit 58c77ad78312c0a16aac95e58f8b579b69198896.

I think we shouldn't change the retry duration and number of attempts until the bug is fixed in the rpc :

```sql
SELECT
    retrying_count,
    COUNT(*) as count
FROM
(SELECT
    arrayJoin(arrayFilter(x -> x.1 = 'slot', fields)).2 AS slot,
    COUNT(*) AS retrying_count
FROM event_log
WHERE
    message = 'retrying missing block'
    AND service = 'neon-indexer'
    AND hostname = 'et-neon-proxy-03.tt-int.net'
    AND datetime <= '2024-09-05 00:00:00.000000000'
    AND datetime >= '2024-09-01 00:00:00.000000000'
GROUP BY slot) AS counts
GROUP BY retrying_count;
```

<img width="380" alt="Cursor_and_DataGripProjects_–_console_2__ch-log-test_tt-int_net_" src="https://github.com/user-attachments/assets/4582177b-bcd2-448a-8a2d-95f23119e74b">


 