### PR TITLE
fix(executor): fix panic when trying to recover incomplete holder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ dependencies = [
  "neon-lib",
  "reth-primitives",
  "reth-rpc-types",
+ "rlp",
  "solana-account-decoder",
  "solana-sdk",
  "solana-transaction-status",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,6 +12,7 @@ hex.workspace = true
 ethnum.workspace = true
 
 build-info = { version = "0.0.31", features = ["serde"] }
+rlp = "0.5.2"
 
 alloy-consensus.workspace = true
 anyhow.workspace = true

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -46,3 +46,18 @@ pub mod neon_instruction {
         pub const TX_STEP_FROM_ACCOUNT_NO_CHAINID_DEPRECATED: u8 = 0x22;
     }
 }
+
+/// [`evm_loader::types::Transaction::from_rlp`] panic workaround
+// TODO: Fix this in neon-evm
+pub fn has_valid_tx_first_byte(bytes: &[u8]) -> bool {
+    // Legacy transaction format
+    if rlp::Rlp::new(bytes).is_list() {
+        true
+    // It's an EIP-2718 typed TX envelope.
+    } else {
+        match bytes.first() {
+            Some(0x00..=0x02) => true,
+            Some(_) | None => false,
+        }
+    }
+}


### PR DESCRIPTION
Fixes `Unsupported EIP-2718 Transaction type | First byte: <number>` panic on proxy start.

See [this](https://github.com/neonlabsorg/neon-evm/blob/d1e27a753bf40b13234204688315b4e91ac2bdea/evm_loader/program/src/types/transaction.rs#L81)